### PR TITLE
Fix hashedkey generated bug of mount encypted obb

### DIFF
--- a/services/core/java/com/android/server/MountService.java
+++ b/services/core/java/com/android/server/MountService.java
@@ -132,6 +132,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.Formatter;
 
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
@@ -3104,8 +3105,14 @@ class MountService extends IMountService.Stub
                     KeySpec ks = new PBEKeySpec(mKey.toCharArray(), obbInfo.salt,
                             PBKDF2_HASH_ROUNDS, CRYPTO_ALGORITHM_KEY_SIZE);
                     SecretKey key = factory.generateSecret(ks);
-                    BigInteger bi = new BigInteger(key.getEncoded());
-                    hashedKey = bi.toString(16);
+                    byte[] keyBytes = key.getEncoded();
+                    StringBuilder sb = new StringBuilder(keyBytes.length * 2);
+                    Formatter formatter = new Formatter(sb);
+
+                    for(byte b: keyBytes){
+                        formatter.format("%02x", b);
+                    }
+                    hashedKey = sb.toString();
                 } catch (NoSuchAlgorithmException e) {
                     Slog.e(TAG, "Could not load PBKDF2 algorithm", e);
                     sendNewStatusOrIgnore(OnObbStateChangeListener.ERROR_INTERNAL);


### PR DESCRIPTION
I find the reason for some obb file could not be mounted.
The wrong hashedKey generated by BigInteger when:
1. The BigInteger value is negative.
    example:
    key bytes: d9 5c 75 92 a9 43 e4 7c 86 dd 8 10 fb 99 ab 0d
    hashedKey generated by BigInteger: -26a38a6d56bc1b837922f7ef046654f3
    hashedKey generated by the fix: d95c7592a943e47c86dd0810fb99ab0d
2. The BigInteger value less then 0x1000000000000000.
    example:
    key bytes: 03 d8 06 ba 8b 3f d4 8c 24 6e 38 9e c5 e7 98 f5
    hashedKey generated by BigInteger: 3d806ba8b3fd48c246e389ec5e798f5
    hashedKey generated by the fix: 03d806ba8b3fd48c246e389ec5e798f5

issues: https://code.google.com/p/android/issues/detail?id=61344
